### PR TITLE
feat: 비콘 데이터 처리 및 근태 관리 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.mariadb.jdbc:mariadb-java-client:2.7.4'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/mmp/beacon/beacon/domain/repository/BeaconRepository.java
+++ b/src/main/java/com/mmp/beacon/beacon/domain/repository/BeaconRepository.java
@@ -1,0 +1,19 @@
+package com.mmp.beacon.beacon.domain.repository;
+
+import com.mmp.beacon.beacon.domain.Beacon;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface BeaconRepository extends JpaRepository<Beacon, Long> {
+
+    /**
+     * 비콘 MAC 주소로 비콘을 찾습니다.
+     *
+     * @param macAddr 비콘 MAC 주소
+     * @return 해당 MAC 주소에 해당하는 비콘
+     */
+    Optional<Beacon> findByMacAddr(String macAddr);
+}

--- a/src/main/java/com/mmp/beacon/communication/application/handler/BeaconWebSocketHandler.java
+++ b/src/main/java/com/mmp/beacon/communication/application/handler/BeaconWebSocketHandler.java
@@ -12,6 +12,10 @@ import org.springframework.web.socket.handler.TextWebSocketHandler;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
+/**
+ * 비콘 데이터를 처리하기 위한 WebSocket 핸들러 클래스입니다.
+ * 이 클래스는 웹소켓 세션을 관리하고, 수신된 메시지를 처리합니다.
+ */
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -20,17 +24,36 @@ public class BeaconWebSocketHandler extends TextWebSocketHandler {
     private final Set<WebSocketSession> sessions = new CopyOnWriteArraySet<>();
     private final BeaconDataProcessor beaconDataProcessor;
 
+    /**
+     * 웹소켓 연결이 성공적으로 수립된 후 호출됩니다.
+     *
+     * @param session 수립된 웹소켓 세션
+     */
     @Override
     public void afterConnectionEstablished(WebSocketSession session) {
         sessions.add(session);
         log.info("새로운 웹소켓 연결: {}", session.getId());
     }
 
+    /**
+     * 텍스트 메시지를 수신했을 때 호출됩니다.
+     * 수신된 메시지를 BeaconDataProcessor를 통해 처리합니다.
+     *
+     * @param session 메시지를 보낸 웹소켓 세션
+     * @param message 수신된 텍스트 메시지
+     * @throws Exception 메시지 처리 중 발생한 예외
+     */
     @Override
     protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
         beaconDataProcessor.processBeaconData(message.getPayload());
     }
 
+    /**
+     * 웹소켓 연결이 종료된 후 호출됩니다.
+     *
+     * @param session 종료된 웹소켓 세션
+     * @param status  연결 종료 상태
+     */
     @Override
     public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
         sessions.remove(session);

--- a/src/main/java/com/mmp/beacon/communication/application/handler/BeaconWebSocketHandler.java
+++ b/src/main/java/com/mmp/beacon/communication/application/handler/BeaconWebSocketHandler.java
@@ -1,5 +1,7 @@
 package com.mmp.beacon.communication.application.handler;
 
+import com.mmp.beacon.commute.application.BeaconDataProcessor;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.CloseStatus;
@@ -7,13 +9,16 @@ import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
 
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class BeaconWebSocketHandler extends TextWebSocketHandler {
 
-    private final CopyOnWriteArraySet<WebSocketSession> sessions = new CopyOnWriteArraySet<>();
+    private final Set<WebSocketSession> sessions = new CopyOnWriteArraySet<>();
+    private final BeaconDataProcessor beaconDataProcessor;
 
     @Override
     public void afterConnectionEstablished(WebSocketSession session) {
@@ -23,9 +28,7 @@ public class BeaconWebSocketHandler extends TextWebSocketHandler {
 
     @Override
     protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
-        String payload = message.getPayload();
-        log.info("메시지 수신: {}", payload);
-        // TODO: 메시지 처리 로직 구현 (예: 사용자 근태 정보 업데이트)
+        beaconDataProcessor.processBeaconData(message.getPayload());
     }
 
     @Override

--- a/src/main/java/com/mmp/beacon/communication/application/handler/BeaconWebSocketHandler.java
+++ b/src/main/java/com/mmp/beacon/communication/application/handler/BeaconWebSocketHandler.java
@@ -1,0 +1,36 @@
+package com.mmp.beacon.communication.application.handler;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+import java.util.concurrent.CopyOnWriteArraySet;
+
+@Slf4j
+@Component
+public class BeaconWebSocketHandler extends TextWebSocketHandler {
+
+    private final CopyOnWriteArraySet<WebSocketSession> sessions = new CopyOnWriteArraySet<>();
+
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) {
+        sessions.add(session);
+        log.info("새로운 웹소켓 연결: {}", session.getId());
+    }
+
+    @Override
+    protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
+        String payload = message.getPayload();
+        log.info("메시지 수신: {}", payload);
+        // TODO: 메시지 처리 로직 구현 (예: 사용자 근태 정보 업데이트)
+    }
+
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
+        sessions.remove(session);
+        log.info("웹소켓 연결 종료: {}", session.getId());
+    }
+}

--- a/src/main/java/com/mmp/beacon/commute/application/BeaconDataProcessor.java
+++ b/src/main/java/com/mmp/beacon/commute/application/BeaconDataProcessor.java
@@ -1,0 +1,73 @@
+package com.mmp.beacon.commute.application;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mmp.beacon.commute.application.command.BeaconData;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BeaconDataProcessor {
+
+    private final ObjectMapper objectMapper;
+    private final CommuteService commuteService;
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ISO_DATE_TIME;
+
+    public void processBeaconData(String jsonPayload) {
+        try {
+            JsonNode rootNode = objectMapper.readTree(jsonPayload);
+            processGateways(rootNode);
+        } catch (IOException e) {
+            log.error("비콘 JSON 데이터 처리 중 오류 발생: {}", e.getMessage(), e);
+            throw new RuntimeException("비콘 JSON 데이터 처리 중 오류 발생", e);
+        }
+    }
+
+    private void processGateways(JsonNode rootNode) {
+        rootNode.path("gateways").forEach(this::processGateway);
+    }
+
+    private void processGateway(JsonNode gatewayNode) {
+        String gatewayMac = gatewayNode.path("gatewayMac").asText();
+        List<BeaconData> beaconDataList = new ArrayList<>();
+
+        gatewayNode.path("beacons").forEach(beaconNode -> {
+            extractBeaconData(beaconNode).ifPresent(beaconDataList::add);
+        });
+
+        if (!beaconDataList.isEmpty()) {
+            log.info("게이트웨이 {}에 대한 비콘 {}개 처리 중", gatewayMac, beaconDataList.size());
+            commuteService.processAttendance(gatewayMac, beaconDataList);
+        }
+    }
+
+    private Optional<BeaconData> extractBeaconData(JsonNode beaconNode) {
+        String mac = beaconNode.path("mac").asText();
+        String earlyTimestamp = beaconNode.path("earlyTimestamp").asText();
+        String lateTimestamp = beaconNode.path("lateTimestamp").asText();
+
+        if (mac.isEmpty() || earlyTimestamp.isEmpty() || lateTimestamp.isEmpty()) {
+            log.warn("비콘 데이터가 누락되어 처리되지 않음: {}", beaconNode);
+            return Optional.empty();
+        }
+
+        try {
+            LocalDateTime earlyDateTime = LocalDateTime.parse(earlyTimestamp, DATE_TIME_FORMATTER);
+            LocalDateTime lateDateTime = LocalDateTime.parse(lateTimestamp, DATE_TIME_FORMATTER);
+            return Optional.of(new BeaconData(mac, earlyDateTime, lateDateTime));
+        } catch (Exception e) {
+            log.warn("Timestamp 형식 오류 : {}", beaconNode);
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/com/mmp/beacon/commute/application/BeaconDataProcessor.java
+++ b/src/main/java/com/mmp/beacon/commute/application/BeaconDataProcessor.java
@@ -14,6 +14,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * 비콘 데이터를 처리하는 서비스 클래스입니다.
+ * JSON 형식의 비콘 데이터를 파싱하여 게이트웨이와 비콘 데이터를 처리합니다.
+ */
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -23,6 +27,11 @@ public class BeaconDataProcessor {
     private final CommuteService commuteService;
     private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ISO_DATE_TIME;
 
+    /**
+     * JSON 형식의 비콘 데이터를 파싱하여 처리합니다.
+     *
+     * @param jsonPayload JSON 형식의 비콘 데이터
+     */
     public void processBeaconData(String jsonPayload) {
         try {
             JsonNode rootNode = objectMapper.readTree(jsonPayload);
@@ -33,10 +42,20 @@ public class BeaconDataProcessor {
         }
     }
 
+    /**
+     * 루트 노드에서 게이트웨이 데이터를 처리합니다.
+     *
+     * @param rootNode JSON 루트 노드
+     */
     private void processGateways(JsonNode rootNode) {
         rootNode.path("gateways").forEach(this::processGateway);
     }
 
+    /**
+     * 개별 게이트웨이 노드를 처리합니다.
+     *
+     * @param gatewayNode JSON 형식의 게이트웨이 노드
+     */
     private void processGateway(JsonNode gatewayNode) {
         String gatewayMac = gatewayNode.path("gatewayMac").asText();
         List<BeaconData> beaconDataList = new ArrayList<>();
@@ -51,6 +70,12 @@ public class BeaconDataProcessor {
         }
     }
 
+    /**
+     * 비콘 노드에서 비콘 데이터를 추출합니다.
+     *
+     * @param beaconNode JSON 형식의 비콘 노드
+     * @return 추출된 비콘 데이터, 유효하지 않은 경우 빈 Optional
+     */
     private Optional<BeaconData> extractBeaconData(JsonNode beaconNode) {
         String mac = beaconNode.path("mac").asText();
         String earlyTimestamp = beaconNode.path("earlyTimestamp").asText();

--- a/src/main/java/com/mmp/beacon/commute/application/CommuteService.java
+++ b/src/main/java/com/mmp/beacon/commute/application/CommuteService.java
@@ -1,0 +1,221 @@
+package com.mmp.beacon.commute.application;
+
+import com.mmp.beacon.beacon.domain.Beacon;
+import com.mmp.beacon.beacon.domain.repository.BeaconRepository;
+import com.mmp.beacon.commute.application.command.BeaconData;
+import com.mmp.beacon.commute.domain.AttendanceStatus;
+import com.mmp.beacon.commute.domain.Commute;
+import com.mmp.beacon.commute.domain.WorkStatus;
+import com.mmp.beacon.commute.domain.repository.CommuteRepository;
+import com.mmp.beacon.gateway.domain.Gateway;
+import com.mmp.beacon.gateway.domain.repository.GatewayRepository;
+import com.mmp.beacon.user.domain.User;
+import com.mmp.beacon.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CommuteService {
+
+    private final GatewayRepository gatewayRepository;
+    private final UserRepository userRepository;
+    private final CommuteRepository commuteRepository;
+    private final BeaconRepository beaconRepository;
+
+    /**
+     * 주어진 게이트웨이 MAC 주소와 비콘 데이터 리스트를 사용하여 근태 관리를 수행합니다.
+     * 오늘이 근무일이 아닌 경우 로그를 남기고 처리를 중단합니다.
+     * 게이트웨이를 찾은 후, 각 비콘 데이터를 개별적으로 처리합니다.
+     * 만약 게이트웨이를 찾지 못하면 경고 로그를 남깁니다.
+     *
+     * @param gatewayMac     게이트웨이 MAC 주소
+     * @param beaconDataList 비콘 데이터 리스트
+     */
+    @Transactional
+    public void processAttendance(String gatewayMac, List<BeaconData> beaconDataList) {
+        if (isWeekend()) {
+            log.info("오늘은 근무일이 아니어서 비콘 데이터 처리를 중단합니다.");
+            return;
+        }
+
+        gatewayRepository.findByMacAddr(gatewayMac)
+                .ifPresentOrElse(
+                        gateway -> beaconDataList.forEach(beaconData -> handleBeaconData(gateway, beaconData)),
+                        () -> log.warn("게이트웨이 {}가 존재하지 않아 비콘 데이터 처리를 중단합니다.", gatewayMac)
+                );
+    }
+
+    /**
+     * 주어진 게이트웨이와 비콘 데이터를 사용하여 개별 비콘 데이터를 처리합니다.
+     * 사용자를 찾고, 사용자가 속한 회사와 게이트웨이가 속한 회사가 일치하는 경우에만 데이터를 처리합니다.
+     * 일치하지 않으면 경고 로그를 남깁니다.
+     *
+     * @param gateway    게이트웨이 엔티티
+     * @param beaconData 비콘 데이터
+     */
+    private void handleBeaconData(Gateway gateway, BeaconData beaconData) {
+        beaconRepository.findByMacAddr(beaconData.mac())
+                .map(Beacon::getUser)
+                .ifPresentOrElse(
+                        user -> {
+                            if (user.getCompany().equals(gateway.getCompany())) {
+                                processBeaconData(user, beaconData);
+                            } else {
+                                log.warn("게이트웨이 {}와 사용자 {}의 회사가 일치하지 않아 비콘 데이터 처리를 중단합니다.",
+                                        gateway.getMacAddr(), user.getId());
+                            }
+                        },
+                        () -> log.warn("비콘 MAC 주소 {}에 해당하는 사용자가 존재하지 않아 비콘 데이터 처리를 중단합니다.", beaconData.mac())
+                );
+    }
+
+    /**
+     * 주어진 사용자와 비콘 데이터를 사용하여 비콘 데이터를 처리합니다.
+     * 사용자의 출퇴근 기록을 찾고, 존재하는 경우 업데이트하고, 존재하지 않는 경우 새로 생성합니다.
+     *
+     * @param user       사용자 엔티티
+     * @param beaconData 비콘 데이터
+     */
+    private void processBeaconData(User user, BeaconData beaconData) {
+        LocalDate today = LocalDate.now();
+        commuteRepository.findByUserAndDate(user, today)
+                .ifPresentOrElse(
+                        commute -> handleExistingCommute(commute, beaconData),
+                        () -> handleNewCommute(user, beaconData)
+                );
+    }
+
+    /**
+     * 기존 출퇴근 기록이 있는 경우 이를 갱신합니다.
+     * 출퇴근 기록의 근무 상태와 시간을 업데이트한 후 저장합니다.
+     *
+     * @param commute    출퇴근 엔티티
+     * @param beaconData 비콘 데이터
+     */
+    private void handleExistingCommute(Commute commute, BeaconData beaconData) {
+        commute.updateWorkStatus(WorkStatus.IN_OFFICE);
+        commute.updateTimestamps(beaconData.earlyTimestamp().toLocalTime(), beaconData.lateTimestamp().toLocalTime());
+        commuteRepository.save(commute);
+    }
+
+    /**
+     * 새로운 출퇴근 기록을 생성합니다.
+     * 만약 비콘 데이터의 earlyTimestamp가 설정된 출근 시간보다 이르면 출근 처리하고,
+     * 그렇지 않으면 지각으로 기록합니다.
+     *
+     * @param user       사용자 엔티티
+     * @param beaconData 비콘 데이터
+     */
+    private void handleNewCommute(User user, BeaconData beaconData) {
+        if (beaconData.earlyTimestamp().toLocalTime().isBefore(user.getCompany().getStartTime())) {
+            markPresent(user, beaconData);
+        } else {
+            markLateArrival(user);
+        }
+    }
+
+    /**
+     * 사용자의 출근 기록을 생성합니다.
+     * 주어진 사용자, 비콘 데이터, 출석 상태, 근무 상태를 사용하여 출퇴근 기록을 생성하고 저장합니다.
+     *
+     * @param user       사용자 엔티티
+     * @param beaconData 비콘 데이터
+     */
+    private void markPresent(User user, BeaconData beaconData) {
+        commuteRepository.save(Commute.builder()
+                .user(user)
+                .date(beaconData.earlyTimestamp().toLocalDate())
+                .startedAt(beaconData.earlyTimestamp().toLocalTime())
+                .endedAt(beaconData.lateTimestamp().toLocalTime())
+                .attendanceStatus(AttendanceStatus.PRESENT)
+                .workStatus(WorkStatus.IN_OFFICE)
+                .build());
+    }
+
+    /**
+     * 오늘의 지각자를 기록합니다.
+     * 오늘이 근무일이 아닌 경우 로그를 남기고 처리를 중단합니다.
+     * 모든 사용자를 조회하여 출퇴근 기록이 없는 사용자를 지각자로 기록합니다.
+     * 이 메소드는 스케줄러에 의해 사용자 회사의 출근 시간에 호출됩니다.
+     */
+    @Transactional
+    public void markLateArrivals() {
+        if (isWeekend()) {
+            log.info("오늘은 근무일이 아니어서 지각 처리를 중단합니다.");
+            return;
+        }
+        LocalDate today = LocalDate.now();
+        userRepository.findAll().stream()
+                .filter(user -> commuteRepository.findByUserAndDate(user, today).isEmpty())
+                .forEach(this::markLateArrival);
+    }
+
+    /**
+     * 주어진 사용자를 지각자로 기록합니다.
+     * 사용자와 현재 날짜를 사용하여 새로운 출퇴근 기록을 생성하고, 지각 상태로 저장합니다.
+     *
+     * @param user 사용자 엔티티
+     */
+    private void markLateArrival(User user) {
+        commuteRepository.save(Commute.builder()
+                .user(user)
+                .startedAt(null)
+                .endedAt(null)
+                .attendanceStatus(AttendanceStatus.LATE)
+                .workStatus(WorkStatus.OUT_OFF_OFFICE)
+                .build());
+    }
+
+    /**
+     * 오늘의 결근자를 기록합니다.
+     * 오늘이 근무일이 아닌 경우 로그를 남기고 처리를 중단합니다.
+     * 모든 사용자를 조회하여 출퇴근 기록이 존재하고, 지각 상태이며 출근 및 퇴근 시간이 사용자를 결근자로 기록합니다.
+     * 이 메소드는 스케줄러에 의해 사용자 회사의 퇴근 시간에 호출됩니다.
+     */
+    @Transactional
+    public void markAbsentees() {
+        if (isWeekend()) {
+            log.info("오늘은 근무일이 아니어서 결근 처리를 중단합니다.");
+            return;
+        }
+        LocalDate today = LocalDate.now();
+        userRepository.findAll().stream()
+                .map(user -> commuteRepository.findByUserAndDate(user, today))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .filter(commute -> commute.getAttendanceStatus() == AttendanceStatus.LATE && commute.getStartedAt() == null && commute.getEndedAt() == null)
+                .forEach(this::markAbsent);
+    }
+
+    /**
+     * 주어진 출퇴근 기록을 결근으로 기록합니다.
+     * 출퇴근 기록의 출석 상태를 결근으로 업데이트한 후 저장합니다.
+     *
+     * @param commute 출퇴근 엔티티
+     */
+    private void markAbsent(Commute commute) {
+        commute.updateAttendanceStatus(AttendanceStatus.ABSENT);
+        commuteRepository.save(commute);
+    }
+
+    /**
+     * 오늘이 근무일인지 확인합니다.
+     * 오늘 날짜의 요일을 확인하여 토요일이나 일요일이 아닌 경우 근무일로 간주합니다.
+     *
+     * @return 오늘이 근무일이면 true, 아니면 false
+     */
+    private boolean isWeekend() {
+        LocalDate today = LocalDate.now();
+        DayOfWeek dayOfWeek = today.getDayOfWeek();
+        return dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY;
+    }
+}

--- a/src/main/java/com/mmp/beacon/commute/application/CommuteService.java
+++ b/src/main/java/com/mmp/beacon/commute/application/CommuteService.java
@@ -245,6 +245,6 @@ public class CommuteService {
     private boolean isWeekend() {
         LocalDate today = timeService.nowDate();
         DayOfWeek dayOfWeek = today.getDayOfWeek();
-        return dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY;
+        return dayOfWeek == DayOfWeek .SATURDAY || dayOfWeek == DayOfWeek.SUNDAY;
     }
 }

--- a/src/main/java/com/mmp/beacon/commute/application/CommuteService.java
+++ b/src/main/java/com/mmp/beacon/commute/application/CommuteService.java
@@ -245,6 +245,6 @@ public class CommuteService {
     private boolean isWeekend() {
         LocalDate today = timeService.nowDate();
         DayOfWeek dayOfWeek = today.getDayOfWeek();
-        return dayOfWeek == DayOfWeek .SATURDAY || dayOfWeek == DayOfWeek.SUNDAY;
+        return dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY;
     }
 }

--- a/src/main/java/com/mmp/beacon/commute/application/CommuteService.java
+++ b/src/main/java/com/mmp/beacon/commute/application/CommuteService.java
@@ -168,6 +168,7 @@ public class CommuteService {
     private void markLateArrival(User user) {
         commuteRepository.save(Commute.builder()
                 .user(user)
+                .date(LocalDate.now())
                 .startedAt(null)
                 .endedAt(null)
                 .attendanceStatus(AttendanceStatus.LATE)

--- a/src/main/java/com/mmp/beacon/commute/application/SystemTimeService.java
+++ b/src/main/java/com/mmp/beacon/commute/application/SystemTimeService.java
@@ -1,0 +1,33 @@
+package com.mmp.beacon.commute.application;
+
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * 실제 시스템 시간을 제공하는 구현 클래스입니다.
+ */
+@Service
+public class SystemTimeService implements TimeService {
+
+    /**
+     * 현재 시스템 시간을 반환합니다.
+     *
+     * @return 현재 LocalDateTime 객체
+     */
+    @Override
+    public LocalDateTime nowDateTime() {
+        return LocalDateTime.now();
+    }
+
+    /**
+     * 현재 시스템 날짜를 반환합니다.
+     *
+     * @return 현재 LocalDate 객체
+     */
+    @Override
+    public LocalDate nowDate() {
+        return LocalDate.now();
+    }
+}

--- a/src/main/java/com/mmp/beacon/commute/application/TimeService.java
+++ b/src/main/java/com/mmp/beacon/commute/application/TimeService.java
@@ -1,0 +1,24 @@
+package com.mmp.beacon.commute.application;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * 현재 시간을 제공하는 서비스 인터페이스입니다.
+ */
+public interface TimeService {
+
+    /**
+     * 현재 시간을 반환합니다.
+     *
+     * @return 현재 LocalDateTime 객체
+     */
+    LocalDateTime nowDateTime();
+
+    /**
+     * 현재 날짜를 반환합니다.
+     *
+     * @return 현재 LocalDate 객체
+     */
+    LocalDate nowDate();
+}

--- a/src/main/java/com/mmp/beacon/commute/application/command/BeaconData.java
+++ b/src/main/java/com/mmp/beacon/commute/application/command/BeaconData.java
@@ -1,0 +1,10 @@
+package com.mmp.beacon.commute.application.command;
+
+import java.time.LocalDateTime;
+
+public record BeaconData(
+        String mac,
+        LocalDateTime earlyTimestamp,
+        LocalDateTime lateTimestamp
+) {
+}

--- a/src/main/java/com/mmp/beacon/commute/application/schedule/CommuteScheduler.java
+++ b/src/main/java/com/mmp/beacon/commute/application/schedule/CommuteScheduler.java
@@ -1,0 +1,32 @@
+package com.mmp.beacon.commute.application.schedule;
+
+import com.mmp.beacon.commute.application.CommuteService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * 스케줄링 작업을 설정하고, 정해진 시간에 특정 작업을 실행하는 클래스입니다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CommuteScheduler {
+
+    private CommuteService commuteService;
+
+    /**
+     * 매 5분마다 자리 비움 또는 퇴근 상태를 업데이트합니다.
+     */
+    @Scheduled(cron = "0 */5 * * * *")
+    public void scheduleMarkLeaveOrOutOffice() {
+        log.info("자리 비움/퇴근 처리 스케줄러 시작");
+        try {
+            commuteService.markLeaveOrOutOffice();
+        } catch (Exception e) {
+            log.error("자리 비움/퇴근 처리 중 오류 발생: {}", e.getMessage());
+        }
+        log.info("자리 비움/퇴근 처리 스케줄러 종료");
+    }
+}

--- a/src/main/java/com/mmp/beacon/commute/application/schedule/CompanyScheduleService.java
+++ b/src/main/java/com/mmp/beacon/commute/application/schedule/CompanyScheduleService.java
@@ -1,6 +1,7 @@
 package com.mmp.beacon.commute.application.schedule;
 
 import com.mmp.beacon.commute.application.CommuteService;
+import com.mmp.beacon.commute.application.TimeService;
 import com.mmp.beacon.company.domain.Company;
 import com.mmp.beacon.company.domain.repository.CompanyRepository;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +23,7 @@ public class CompanyScheduleService implements ScheduleService {
 
     private final TaskScheduler taskScheduler;
     private final CommuteService commuteService;
+    private final TimeService timeService;
     private final CompanyRepository companyRepository;
 
     /**
@@ -60,7 +62,7 @@ public class CompanyScheduleService implements ScheduleService {
      * @param task 실행할 작업
      */
     private void scheduleTask(LocalTime time, Runnable task) {
-        Trigger trigger = createTrigger(LocalDateTime.now().with(time));
+        Trigger trigger = createTrigger(timeService.nowDateTime().with(time));
         taskScheduler.schedule(task, trigger);
     }
 

--- a/src/main/java/com/mmp/beacon/commute/application/schedule/CompanyScheduleService.java
+++ b/src/main/java/com/mmp/beacon/commute/application/schedule/CompanyScheduleService.java
@@ -1,0 +1,76 @@
+package com.mmp.beacon.commute.application.schedule;
+
+import com.mmp.beacon.commute.application.CommuteService;
+import com.mmp.beacon.company.domain.Company;
+import com.mmp.beacon.company.domain.repository.CompanyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.Trigger;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+
+/**
+ * 회사별 스케줄 작업을 관리하는 서비스 클래스입니다.
+ */
+@Service
+@RequiredArgsConstructor
+public class CompanyScheduleService implements ScheduleService {
+
+    private final TaskScheduler taskScheduler;
+    private final CommuteService commuteService;
+    private final CompanyRepository companyRepository;
+
+    /**
+     * 매일 모든 회사의 출근 및 퇴근 시간을 기반으로 스케줄 작업을 등록합니다.
+     */
+    @Scheduled(cron = "0 0 0 * * *")
+    public void scheduleDailyCompanyTasks() {
+        companyRepository.findAll().forEach(this::scheduleCompanyTasks);
+    }
+
+    /**
+     * 회사의 출근 및 퇴근 시간을 기반으로 스케줄 작업을 등록합니다.
+     *
+     * @param company 회사 엔티티
+     */
+    @Override
+    public void scheduleCompanyTasks(Company company) {
+        scheduleTask(company.getStartTime(), () -> commuteService.markLateArrivals(company.getId()));
+        scheduleTask(company.getEndTime(), () -> commuteService.markAbsentees(company.getId()));
+    }
+
+    /**
+     * 기존 스케줄 작업을 취소하고 새로운 스케줄 작업을 등록합니다.
+     *
+     * @param company 회사 엔티티
+     */
+    @Override
+    public void rescheduleCompanyTasks(Company company) {
+        scheduleCompanyTasks(company);
+    }
+
+    /**
+     * 주어진 시간에 스케줄 작업을 등록합니다.
+     *
+     * @param time 작업 실행 시간
+     * @param task 실행할 작업
+     */
+    private void scheduleTask(LocalTime time, Runnable task) {
+        Trigger trigger = createTrigger(LocalDateTime.now().with(time));
+        taskScheduler.schedule(task, trigger);
+    }
+
+    /**
+     * 주어진 시간에 실행되는 트리거를 생성합니다.
+     *
+     * @param time 작업 실행 시간
+     * @return 생성된 트리거
+     */
+    private Trigger createTrigger(LocalDateTime time) {
+        return triggerContext -> time.atZone(ZoneId.systemDefault()).toInstant();
+    }
+}

--- a/src/main/java/com/mmp/beacon/commute/application/schedule/CompanyUpdateService.java
+++ b/src/main/java/com/mmp/beacon/commute/application/schedule/CompanyUpdateService.java
@@ -1,0 +1,24 @@
+package com.mmp.beacon.commute.application.schedule;
+
+import com.mmp.beacon.company.domain.Company;
+import com.mmp.beacon.company.domain.repository.CompanyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 회사 정보를 업데이트하고, 스케줄 작업을 재등록하는 서비스 클래스입니다.
+ */
+@Service
+@RequiredArgsConstructor
+public class CompanyUpdateService {
+
+    private final CompanyScheduleService companyScheduleService;
+    private final CompanyRepository companyRepository;
+
+    @Transactional
+    public void updateCompany(Company company) {
+        companyRepository.save(company);
+        companyScheduleService.rescheduleCompanyTasks(company);
+    }
+}

--- a/src/main/java/com/mmp/beacon/commute/application/schedule/ScheduleService.java
+++ b/src/main/java/com/mmp/beacon/commute/application/schedule/ScheduleService.java
@@ -1,0 +1,23 @@
+package com.mmp.beacon.commute.application.schedule;
+
+import com.mmp.beacon.company.domain.Company;
+
+/**
+ * 회사별 스케줄 작업을 관리하기 위한 인터페이스입니다.
+ */
+public interface ScheduleService {
+
+    /**
+     * 회사별 스케줄 작업을 등록합니다.
+     *
+     * @param company 회사 엔티티
+     */
+    void scheduleCompanyTasks(Company company);
+
+    /**
+     * 회사별 스케줄 작업을 재등록합니다.
+     *
+     * @param company 회사 엔티티
+     */
+    void rescheduleCompanyTasks(Company company);
+}

--- a/src/main/java/com/mmp/beacon/commute/domain/AttendanceStatus.java
+++ b/src/main/java/com/mmp/beacon/commute/domain/AttendanceStatus.java
@@ -1,8 +1,7 @@
 package com.mmp.beacon.commute.domain;
 
 public enum AttendanceStatus {
-    CHECKED_IN,
-    CHECKED_OUT,
-    ABSENT,
-    LATE
+    PRESENT,
+    LATE,
+    ABSENT
 }

--- a/src/main/java/com/mmp/beacon/commute/domain/Commute.java
+++ b/src/main/java/com/mmp/beacon/commute/domain/Commute.java
@@ -9,7 +9,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 @Getter
@@ -74,7 +73,7 @@ public class Commute extends BaseEntity {
      * 주어진 출근 시간(earlyTimestamp)이 현재 출근 시간보다 이른 경우, 출근 시간을 갱신합니다.
      * 주어진 퇴근 시간(latestTimestamp)이 현재 퇴근 시간보다 늦은 경우, 퇴근 시간을 갱신합니다.
      *
-     * @param earlyTimestamp 새로운 출근 시간
+     * @param earlyTimestamp  새로운 출근 시간
      * @param latestTimestamp 새로운 퇴근 시간
      */
     public void updateTimestamps(LocalTime earlyTimestamp, LocalTime latestTimestamp) {

--- a/src/main/java/com/mmp/beacon/commute/domain/Commute.java
+++ b/src/main/java/com/mmp/beacon/commute/domain/Commute.java
@@ -4,10 +4,13 @@ import com.mmp.beacon.global.domain.BaseEntity;
 import com.mmp.beacon.user.domain.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 @Getter
 @Entity
@@ -24,26 +27,62 @@ public class Commute extends BaseEntity {
     @JoinColumn(name = "user_no", nullable = false)
     private User user;
 
-    @Column(name = "is_active", nullable = false)
-    private Boolean isActive;
+    @Column(name = "commute_date", nullable = false)
+    private LocalDate date;
 
-    @Column(name = "commute_started_at", updatable = false, nullable = false)
-    private LocalDateTime startedAt;
+    @Column(name = "commute_started_at")
+    private LocalTime startedAt;
 
-    @Column(name = "commute_ended_at", nullable = false)
-    private LocalDateTime endedAt;
+    @Column(name = "commute_ended_at")
+    private LocalTime endedAt;
 
-    @Column(name = "attendance_status")
+    @Column(name = "attendance_status", nullable = false)
     @Enumerated(EnumType.STRING)
     private AttendanceStatus attendanceStatus;
 
-    @PrePersist
-    public void onPrePersist() {
-        this.startedAt = this.getCreateAt();
+    @Column(name = "work_status", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private WorkStatus workStatus;
+
+    @Builder
+    public Commute(
+            User user,
+            LocalDate date,
+            LocalTime startedAt,
+            LocalTime endedAt,
+            AttendanceStatus attendanceStatus,
+            WorkStatus workStatus
+    ) {
+        this.user = user;
+        this.date = date;
+        this.startedAt = startedAt;
+        this.endedAt = endedAt;
+        this.attendanceStatus = attendanceStatus;
+        this.workStatus = workStatus;
     }
 
-    @PreUpdate
-    public void onPreUpdate() {
-        this.endedAt = this.getUpdateAt();
+    public void updateWorkStatus(WorkStatus workStatus) {
+        this.workStatus = workStatus;
+    }
+
+    public void updateAttendanceStatus(AttendanceStatus attendanceStatus) {
+        this.attendanceStatus = attendanceStatus;
+    }
+
+    /**
+     * Commute 엔티티의 출근 시간과 퇴근 시간을 갱신합니다.
+     * 주어진 출근 시간(earlyTimestamp)이 현재 출근 시간보다 이른 경우, 출근 시간을 갱신합니다.
+     * 주어진 퇴근 시간(latestTimestamp)이 현재 퇴근 시간보다 늦은 경우, 퇴근 시간을 갱신합니다.
+     *
+     * @param earlyTimestamp 새로운 출근 시간
+     * @param latestTimestamp 새로운 퇴근 시간
+     */
+    public void updateTimestamps(LocalTime earlyTimestamp, LocalTime latestTimestamp) {
+        if (this.startedAt == null || earlyTimestamp.isBefore(this.startedAt)) {
+            this.startedAt = earlyTimestamp;
+        }
+        if (this.endedAt == null || latestTimestamp.isAfter(this.endedAt)) {
+            this.endedAt = latestTimestamp;
+        }
     }
 }

--- a/src/main/java/com/mmp/beacon/commute/domain/WorkStatus.java
+++ b/src/main/java/com/mmp/beacon/commute/domain/WorkStatus.java
@@ -1,0 +1,6 @@
+package com.mmp.beacon.commute.domain;
+
+public enum WorkStatus {
+    IN_OFFICE,
+    OUT_OFF_OFFICE
+}

--- a/src/main/java/com/mmp/beacon/commute/domain/repository/CommuteRepository.java
+++ b/src/main/java/com/mmp/beacon/commute/domain/repository/CommuteRepository.java
@@ -1,0 +1,22 @@
+package com.mmp.beacon.commute.domain.repository;
+
+import com.mmp.beacon.commute.domain.Commute;
+import com.mmp.beacon.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+@Repository
+public interface CommuteRepository extends JpaRepository<Commute, Long> {
+
+    /**
+     * 사용자와 날짜로 출퇴근 기록을 찾습니다.
+     *
+     * @param user 사용자 엔티티
+     * @param date 날짜
+     * @return 해당 사용자와 날짜에 해당하는 출퇴근 기록
+     */
+    Optional<Commute> findByUserAndDate(User user, LocalDate date);
+}

--- a/src/main/java/com/mmp/beacon/company/domain/Company.java
+++ b/src/main/java/com/mmp/beacon/company/domain/Company.java
@@ -6,6 +6,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalTime;
+
 @Getter
 @Entity
 @Table(name = "company")
@@ -19,4 +21,10 @@ public class Company extends BaseEntity {
 
     @Column(name = "company_name", length = 50, nullable = false)
     private String name;
+
+    @Column(name = "start_time", nullable = false)
+    private LocalTime startTime;
+
+    @Column(name = "end_time", nullable = false)
+    private LocalTime endTime;
 }

--- a/src/main/java/com/mmp/beacon/company/domain/repository/CompanyRepository.java
+++ b/src/main/java/com/mmp/beacon/company/domain/repository/CompanyRepository.java
@@ -1,0 +1,9 @@
+package com.mmp.beacon.company.domain.repository;
+
+import com.mmp.beacon.company.domain.Company;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CompanyRepository extends JpaRepository<Company, Long> {
+}

--- a/src/main/java/com/mmp/beacon/gateway/domain/Gateway.java
+++ b/src/main/java/com/mmp/beacon/gateway/domain/Gateway.java
@@ -22,7 +22,6 @@ public class Gateway extends BaseEntity {
     @JoinColumn(name = "company_no", nullable = false)
     private Company company;
 
-    @Column(name = "gateway_name", length = 50, nullable = false)
-    private String name;
-
+    @Column(name = "gateway_mac_addr", length = 50, nullable = false)
+    private String macAddr;
 }

--- a/src/main/java/com/mmp/beacon/gateway/domain/repository/GatewayRepository.java
+++ b/src/main/java/com/mmp/beacon/gateway/domain/repository/GatewayRepository.java
@@ -1,0 +1,19 @@
+package com.mmp.beacon.gateway.domain.repository;
+
+import com.mmp.beacon.gateway.domain.Gateway;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface GatewayRepository extends JpaRepository<Gateway, Long> {
+
+    /**
+     * MAC 주소로 게이트웨이를 찾습니다.
+     *
+     * @param macAddr 게이트웨이 MAC 주소
+     * @return 해당 MAC 주소에 해당하는 게이트웨이
+     */
+    Optional<Gateway> findByMacAddr(String macAddr);
+}

--- a/src/main/java/com/mmp/beacon/global/config/SchedulerConfig.java
+++ b/src/main/java/com/mmp/beacon/global/config/SchedulerConfig.java
@@ -1,0 +1,28 @@
+package com.mmp.beacon.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+/**
+ * SchedulerConfig 클래스는 스케줄링을 위한 TaskScheduler를 설정합니다.
+ */
+@Configuration
+public class SchedulerConfig {
+
+    /**
+     * TaskScheduler 빈을 생성합니다.
+     * 스레드 풀의 크기와 스레드 이름 접두사를 설정합니다.
+     *
+     * @return TaskScheduler 인스턴스
+     */
+    @Bean
+    public TaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
+        taskScheduler.setPoolSize(10);
+        taskScheduler.setThreadNamePrefix("scheduler-");
+        taskScheduler.initialize();
+        return taskScheduler;
+    }
+}

--- a/src/main/java/com/mmp/beacon/global/config/WebSocketConfig.java
+++ b/src/main/java/com/mmp/beacon/global/config/WebSocketConfig.java
@@ -1,0 +1,26 @@
+package com.mmp.beacon.global.config;
+
+import com.mmp.beacon.communication.application.handler.BeaconWebSocketHandler;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+import org.springframework.web.socket.server.support.HttpSessionHandshakeInterceptor;
+
+@Configuration
+@EnableWebSocket
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketConfigurer {
+
+    private final BeaconWebSocketHandler beaconWebSocketHandler;
+
+    @Override
+    public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+        registry.addHandler(beaconWebSocketHandler, "/ws/beacon")
+                .setAllowedOrigins("*")
+                .addInterceptors(new HttpSessionHandshakeInterceptor());
+    }
+}

--- a/src/main/java/com/mmp/beacon/global/config/WebSocketConfig.java
+++ b/src/main/java/com/mmp/beacon/global/config/WebSocketConfig.java
@@ -2,8 +2,6 @@ package com.mmp.beacon.global.config;
 
 import com.mmp.beacon.communication.application.handler.BeaconWebSocketHandler;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;

--- a/src/main/java/com/mmp/beacon/global/config/WebSocketConfig.java
+++ b/src/main/java/com/mmp/beacon/global/config/WebSocketConfig.java
@@ -8,6 +8,10 @@ import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
 import org.springframework.web.socket.server.support.HttpSessionHandshakeInterceptor;
 
+/**
+ * 웹소켓 설정을 위한 구성 클래스입니다.
+ * 이 클래스는 웹소켓 핸들러를 등록하고 설정합니다.
+ */
 @Configuration
 @EnableWebSocket
 @RequiredArgsConstructor
@@ -15,6 +19,11 @@ public class WebSocketConfig implements WebSocketConfigurer {
 
     private final BeaconWebSocketHandler beaconWebSocketHandler;
 
+    /**
+     * 웹소켓 핸들러를 등록합니다.
+     *
+     * @param registry 웹소켓 핸들러 레지스트리
+     */
     @Override
     public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
         registry.addHandler(beaconWebSocketHandler, "/ws/beacon")

--- a/src/main/java/com/mmp/beacon/request/domain/PasswordResetRequest.java
+++ b/src/main/java/com/mmp/beacon/request/domain/PasswordResetRequest.java
@@ -1,6 +1,5 @@
 package com.mmp.beacon.request.domain;
 
-import com.mmp.beacon.global.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/src/main/java/com/mmp/beacon/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/mmp/beacon/user/domain/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package com.mmp.beacon.user.domain.repository;
+
+import com.mmp.beacon.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/mmp/beacon/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/mmp/beacon/user/domain/repository/UserRepository.java
@@ -4,6 +4,16 @@ import com.mmp.beacon.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    /**
+     * 주어진 회사 ID를 사용하여 해당 회사에 소속된 모든 사용자를 조회합니다.
+     *
+     * @param companyId 조회할 회사의 ID
+     * @return 해당 회사에 소속된 사용자 목록
+     */
+    List<User> findByCompanyId(Long companyId);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     password: qwerasdf
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true

--- a/src/test/java/com/mmp/beacon/commute/application/CommuteServiceTest.java
+++ b/src/test/java/com/mmp/beacon/commute/application/CommuteServiceTest.java
@@ -236,4 +236,31 @@ class CommuteServiceTest {
         assertEquals(AttendanceStatus.PRESENT, commute2.getAttendanceStatus());
         assertEquals(WorkStatus.IN_OFFICE, commute2.getWorkStatus());
     }
+
+    @Test
+    @DisplayName("퇴근 또는 자리 비움을 기록한다.")
+    void testMarkLeaveOrOutOffice() {
+        // Given
+        User user = mock(User.class);
+        Commute existingCommute = new Commute(user, LocalDate.of(2024, 7, 23), LocalTime.of(9, 0), LocalTime.of(18, 0), AttendanceStatus.PRESENT, WorkStatus.IN_OFFICE);
+
+        when(timeService.nowDate()).thenReturn(LocalDate.of(2024, 7, 23));
+        when(timeService.nowDateTime()).thenReturn(LocalDateTime.of(2024, 7, 23, 18, 6));
+        when(userRepository.findAll()).thenReturn(List.of(user));
+        when(commuteRepository.findByUserAndDate(user, LocalDate.of(2024, 7, 23))).thenReturn(Optional.of(existingCommute));
+
+        // When
+        commuteService.markLeaveOrOutOffice();
+
+        // Then
+        verify(commuteRepository, times(1)).save(commuteCapture.capture());
+        Commute updatedCommute = commuteCapture.getValue();
+
+        assertEquals(user, updatedCommute.getUser());
+        assertEquals(LocalDate.of(2024, 7, 23), updatedCommute.getDate());
+        assertEquals(LocalTime.of(9, 0), updatedCommute.getStartedAt());
+        assertEquals(LocalTime.of(18, 0), updatedCommute.getEndedAt());
+        assertEquals(AttendanceStatus.PRESENT, updatedCommute.getAttendanceStatus());
+        assertEquals(WorkStatus.OUT_OFF_OFFICE, updatedCommute.getWorkStatus());
+    }
 }

--- a/src/test/java/com/mmp/beacon/commute/application/CommuteServiceTest.java
+++ b/src/test/java/com/mmp/beacon/commute/application/CommuteServiceTest.java
@@ -1,0 +1,143 @@
+package com.mmp.beacon.commute.application;
+
+import com.mmp.beacon.beacon.domain.Beacon;
+import com.mmp.beacon.beacon.domain.repository.BeaconRepository;
+import com.mmp.beacon.commute.application.command.BeaconData;
+import com.mmp.beacon.commute.domain.AttendanceStatus;
+import com.mmp.beacon.commute.domain.Commute;
+import com.mmp.beacon.commute.domain.WorkStatus;
+import com.mmp.beacon.commute.domain.repository.CommuteRepository;
+import com.mmp.beacon.company.domain.Company;
+import com.mmp.beacon.gateway.domain.Gateway;
+import com.mmp.beacon.gateway.domain.repository.GatewayRepository;
+import com.mmp.beacon.user.domain.User;
+import com.mmp.beacon.user.domain.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.*;
+
+class CommuteServiceTest {
+
+    @Mock
+    private GatewayRepository gatewayRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private CommuteRepository commuteRepository;
+
+    @Mock
+    private BeaconRepository beaconRepository;
+
+    @Mock
+    private TimeService timeService;
+
+    @InjectMocks
+    private CommuteService commuteService;
+
+    @Captor
+    private ArgumentCaptor<Commute> commuteCapture;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    @DisplayName("주어진 게이트웨이 MAC 주소와 비콘 데이터 리스트를 사용하여 기존 출퇴근 기록이 없는 경우 새로운 출퇴근 기록을 생성한다.")
+    void testMarkPresent() {
+        // Given
+        String gatewayMac1 = "40D63CD6FD92";
+        String gatewayMac2 = "50D63CD6FD93";
+
+        BeaconData beaconData1 = new BeaconData("F4741C781187", LocalDateTime.parse("2024-07-23T08:00:00"), LocalDateTime.parse("2024-07-23T08:01:00"));
+        BeaconData beaconData2 = new BeaconData("DE42759B6E12", LocalDateTime.parse("2024-07-23T08:01:00"), LocalDateTime.parse("2024-07-23T08:02:00"));
+        BeaconData beaconData3 = new BeaconData("A1741C781187", LocalDateTime.parse("2024-07-23T08:02:00"), LocalDateTime.parse("2024-07-23T08:03:00"));
+        BeaconData beaconData4 = new BeaconData("BE42759B6E12", LocalDateTime.parse("2024-07-23T08:03:00"), LocalDateTime.parse("2024-07-23T08:04:00"));
+
+        Gateway gateway1 = mock(Gateway.class);
+        Gateway gateway2 = mock(Gateway.class);
+        Company company = mock(Company.class);
+        User user1 = mock(User.class);
+        User user2 = mock(User.class);
+        User user3 = mock(User.class);
+        User user4 = mock(User.class);
+        Beacon beacon1 = mock(Beacon.class);
+        Beacon beacon2 = mock(Beacon.class);
+        Beacon beacon3 = mock(Beacon.class);
+        Beacon beacon4 = mock(Beacon.class);
+
+        when(timeService.nowDate()).thenReturn(LocalDate.of(2024, 7, 23));
+        when(gatewayRepository.findByMacAddr(gatewayMac1)).thenReturn(Optional.of(gateway1));
+        when(gatewayRepository.findByMacAddr(gatewayMac2)).thenReturn(Optional.of(gateway2));
+        when(beaconRepository.findByMacAddr("F4741C781187")).thenReturn(Optional.of(beacon1));
+        when(beaconRepository.findByMacAddr("DE42759B6E12")).thenReturn(Optional.of(beacon2));
+        when(beaconRepository.findByMacAddr("A1741C781187")).thenReturn(Optional.of(beacon3));
+        when(beaconRepository.findByMacAddr("BE42759B6E12")).thenReturn(Optional.of(beacon4));
+        when(beacon1.getUser()).thenReturn(user1);
+        when(beacon2.getUser()).thenReturn(user2);
+        when(beacon3.getUser()).thenReturn(user3);
+        when(beacon4.getUser()).thenReturn(user4);
+        when(gateway1.getCompany()).thenReturn(company);
+        when(gateway2.getCompany()).thenReturn(company);
+        when(user1.getCompany()).thenReturn(company);
+        when(user2.getCompany()).thenReturn(company);
+        when(user3.getCompany()).thenReturn(company);
+        when(user4.getCompany()).thenReturn(company);
+        when(company.getStartTime()).thenReturn(LocalTime.of(9, 0));
+        when(company.getEndTime()).thenReturn(LocalTime.of(18, 0));
+
+        // When
+        commuteService.processAttendance(gatewayMac1, List.of(beaconData1, beaconData2));
+        commuteService.processAttendance(gatewayMac2, List.of(beaconData3, beaconData4));
+
+        // Then
+        verify(commuteRepository, times(4)).save(commuteCapture.capture());
+        List<Commute> savedCommutes = commuteCapture.getAllValues();
+
+        // Assert each saved Commute
+        Commute commute1 = savedCommutes.get(0);
+        assertEquals(user1, commute1.getUser());
+        assertEquals(LocalDate.of(2024, 7, 23), commute1.getDate());
+        assertEquals(LocalTime.of(8, 0), commute1.getStartedAt());
+        assertEquals(LocalTime.of(8, 1), commute1.getEndedAt());
+        assertEquals(AttendanceStatus.PRESENT, commute1.getAttendanceStatus());
+        assertEquals(WorkStatus.IN_OFFICE, commute1.getWorkStatus());
+
+        Commute commute2 = savedCommutes.get(1);
+        assertEquals(user2, commute2.getUser());
+        assertEquals(LocalDate.of(2024, 7, 23), commute2.getDate());
+        assertEquals(LocalTime.of(8, 1), commute2.getStartedAt());
+        assertEquals(LocalTime.of(8, 2), commute2.getEndedAt());
+        assertEquals(AttendanceStatus.PRESENT, commute2.getAttendanceStatus());
+        assertEquals(WorkStatus.IN_OFFICE, commute2.getWorkStatus());
+
+        Commute commute3 = savedCommutes.get(2);
+        assertEquals(user3, commute3.getUser());
+        assertEquals(LocalDate.of(2024, 7, 23), commute3.getDate());
+        assertEquals(LocalTime.of(8, 2), commute3.getStartedAt());
+        assertEquals(LocalTime.of(8, 3), commute3.getEndedAt());
+        assertEquals(AttendanceStatus.PRESENT, commute3.getAttendanceStatus());
+        assertEquals(WorkStatus.IN_OFFICE, commute3.getWorkStatus());
+
+        Commute commute4 = savedCommutes.get(3);
+        assertEquals(user4, commute4.getUser());
+        assertEquals(LocalDate.of(2024, 7, 23), commute4.getDate());
+        assertEquals(LocalTime.of(8, 3), commute4.getStartedAt());
+        assertEquals(LocalTime.of(8, 4), commute4.getEndedAt());
+        assertEquals(AttendanceStatus.PRESENT, commute4.getAttendanceStatus());
+        assertEquals(WorkStatus.IN_OFFICE, commute4.getWorkStatus());
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈  
closed #2 

## 💗 작업 동기
비콘 데이터를 활용하여 직원들의 출퇴근 상태를 자동으로 관리하는 시스템을 구축하였습니다. 이 시스템은 실시간으로 비콘 데이터를 수집하고, 다양한 조건에 따라 직원들의 출퇴근 기록을 생성하거나 업데이트합니다.

### 근태 관리

1. **출근 처리**:
    - 근무일에 출근 시간 이전에 비콘 데이터가 수신되면, 새로운 출근 기록을 생성합니다. 이때, 출근 상태는 `PRESENT`, 업무 상태는 `IN_OFFICE`로 설정되며, 출근 시간과 퇴근 시간은 비콘 데이터에서 추출한 타임스탬프를 기반으로 설정됩니다.
    
2. **지각 처리**:
    - 근무일에 회사 출근 시간이 되었는데 출근 기록이 없으면, 지각으로 처리합니다. 스케줄러가 자동으로 지각자를 식별하고, 새로운 출근 기록을 생성하여 `LATE` 상태로 설정합니다.
    
3. **업무 중 상태 업데이트**:
    - 근무일에 이미 출근 기록이 있는 경우, 추가로 수신된 비콘 데이터를 통해 업무 중 상태를 업데이트합니다. 비콘 데이터의 타임스탬프에 따라 출근 시간과 퇴근 시간을 최신화합니다.
    
4. **퇴근/자리 비움 처리**:
    - 근무일에 일정 시간 동안 비콘 데이터가 수신되지 않으면, 스케줄러가 자동으로 퇴근 또는 자리 비움 상태로 기록을 업데이트합니다.
    
5. **결근 처리**:
    - 근무일에 퇴근 시간까지 출근 기록이 없는 경우, 결근으로 처리합니다. 스케줄러가 자동으로 결근자를 식별하고, 출근 기록을 `ABSENT` 상태로 설정합니다.

### 웹소켓을 사용한 이유
비콘 데이터의 실시간 수신과 처리를 위해 웹소켓을 사용했습니다. 웹소켓은 지속적인 연결을 유지하면서 클라이언트와 서버 간에 실시간 데이터 전송을 가능하게 하므로, 비콘 데이터의 실시간 처리가 필요한 이번 시스템에 적합합니다.

## 🛠️ 작업 내용
### 웹소켓 설정 추가 (global/config/WebSocketConfig.java)
웹소켓 핸들러를 등록하고, 웹소켓 연결을 설정했습니다. 웹소켓 핸들러를 `/ws/beacon` 경로에 등록하고, 모든 출처에서의 접근을 허용하며, 핸드셰이크 인터셉터를 추가했습니다.

### BeaconWebSocketHandler 클래스 추가 (communication/application/handler/BeaconWebSocketHandler.java)
웹소켓 핸들러를 구현하여 실시간으로 비콘 데이터를 수신하고 처리하는 기능을 추가했습니다. 새로운 웹소켓 연결을 추가하고, 수신된 비콘 데이터를 처리하며, 연결이 종료된 세션을 제거하는 역할을 합니다.

### BeaconDataProcessor 클래스 추가 (commute/application/BeaconDataProcessor.java)
비콘 데이터를 처리하는 서비스 클래스를 추가했습니다. JSON 형태의 비콘 데이터를 파싱하고, 개별 게이트웨이와 연결된 비콘 데이터를 처리하는 기능을 담당합니다.

### CommuteService 클래스 추가 (commute/application/CommuteService.java)
출퇴근 기록을 관리하는 서비스 클래스를 추가했습니다. 비콘 데이터를 기반으로 출퇴근 기록을 생성하거나 업데이트하며, 지각자 및 결근자 기록, 자리 비움 및 퇴근 상태를 기록하는 기능을 포함하고 있습니다.

### SystemTimeService 및 TimeService 인터페이스 추가 (commute/application/SystemTimeService.java, commute/application/TimeService.java)
현재 시스템 시간을 제공하는 서비스 인터페이스와 구현 클래스를 추가했습니다. 현재 시간과 날짜를 반환하는 메서드를 제공합니다.

### 스케줄러 설정 추가 (global/config/SchedulerConfig.java)
스케줄 작업을 실행하기 위한 `TaskScheduler` 빈을 설정했습니다. 스레드 풀의 크기와 스레드 이름 접두사를 설정하는 `taskScheduler` 빈을 추가했습니다.

### 스케줄링 서비스 추가 (commute/application/schedule/CompanyScheduleService.java, commute/application/schedule/CommuteScheduler.java, commute/application/schedule/CompanyUpdateService.java, commute/application/schedule/ScheduleService.java)
회사의 출근 및 퇴근 스케줄을 관리하는 서비스 클래스를 추가했습니다. 회사별 출근 및 퇴근 시간에 맞춰 스케줄 작업을 등록하고, 이를 재등록하는 기능을 포함하고 있습니다.

### Commute 엔티티 수정, Company 엔티티 수정, Gateway 엔티티 수정, CommuteRepository 추가, CompanyRepository 추가, GatewayRepository 추가, BeaconRepository 추가, UserRepository 추가 

### 근태 관리 서비스 테스트 추가 (test/java/com/mmp/beacon/commute/application/CommuteServiceTest.java)
`CommuteServiceTest` 클래스를 추가하여 다양한 시나리오에 대한 서비스 메서드를 검증했습니다. 새로운 출퇴근 기록 생성, 기존 출퇴근 기록 업데이트, 지각자 및 결근자 기록, 자리 비움 및 퇴근 상태 기록 등의 시나리오를 테스트했습니다.

## 🎯 리뷰 포인트

1. 출근
    1. 조건
        1. 근무일인 경우
        2. 출근 시간 이전인 경우
        3. BeaconData가 들어온 경우
        4. 오늘 날짜의 Commute 엔티티가 존재하지 않는 경우
    2. 처리
        1. 새로운 Commute 엔티티를 생성한다.
            1. AttendanceStatus를 PRESENT으로 설정
            2. WorkStatus를 IN_OFFICE로 설정
            3. startedAt을 BeaconData의 earlyTimestamp로 설정
            4. endedAt은 BeaconData의 lateTimestamp로 설정
2. 지각
    1. 조건
        1. 근무일인 경우
        2. 회사 출근 시간이 되었을 때 오늘 날짜의 Commute 엔티티가 존재하지 없는 경우
    2. 처리
        1. 스케줄러에 의해 사용자 회사의 출근 시간에 지각 처리한다.
        2. 새로운 Commute 엔티티를 생성한다. → CommuteService `markLateArrivals()` 호출
            1. AttendanceStatus를 LATE로 설정
            2. WorkStatus를 OUT_OFFICE로 설정
            3. startAt과 endedAt을 null로 설정
3. 업무 중
    - 조건
        - 근무일인 경우
        - 오늘 날짜의 Commute 엔티티가 존재하는 경우
        - BeaconData가 들어온 경우
    - 처리
        - 기존의 Commute 엔티티를 업데이트한다.
            - WorkStatus를 IN_OFFICE로 설정
            - earlyTimestamp가 현재 startedAt보다 빠르면 startedAt을 earlyTimestamp로 업데이트한다.
            - lateTimestamp가 현재 endedAt보다 늦으면 endedAt을 lateTimestamp로 업데이트한다.
4. 퇴근/자리 비움
    - 조건
        - 근무일인 경우
        - 오늘 날짜의 Commute 엔티티가 존재하는 경우
        - earlyTimestamp가 현재 시점으로부터 일정 시간(5분)이 지났을 경우
    - 처리
        - 스케줄러에 의해 사용자를 퇴근 처리한다.
        - 기존의 Commute 엔티티를 업데이트한다. → CommuteService `markLeaveOrOutOffice()`
            - WorkStatus를 OUT_OFFICE로 변경
5. 결근
    1. 조건
        1. 근무일인 경우
        2. 퇴근 시간 시점에 startAt과 endedAt이 null인 경우
    2. 처리
        1. 스케줄러에 의해 사용자 회사의 퇴근 시간에 결근 처리한다.
        2. 기존의 Commute 엔티티를 업데이트한다. → CommuteService `markAbsentees()`
            1. AttendanceStatus를 ABSENT로 설정

## ✅ 테스트 결과
![image](https://github.com/user-attachments/assets/25f25a38-a361-4a99-94f6-f2f35572912b)